### PR TITLE
Fixes livelock

### DIFF
--- a/microscoped-core/src/main/java/org/tomitribe/microscoped/core/Scope.java
+++ b/microscoped-core/src/main/java/org/tomitribe/microscoped/core/Scope.java
@@ -43,7 +43,11 @@ class Scope<Key> {
      * @return existing or newly created bean instance, never null
      */
     public <T> T get(final Contextual<T> contextual, final CreationalContext<T> creationalContext) {
-        return (T) instances.computeIfAbsent(contextual, c -> new Instance<>(contextual, creationalContext)).get();
+        if (!instances.containsKey(contextual)) {
+            final Instance<T> instance = new Instance<>(contextual, creationalContext);
+            instances.putIfAbsent(contextual, instance);
+        }
+        return (T) instances.get(contextual).get();
     }
 
     /**


### PR DESCRIPTION
This fixes a livelock when a custom scoped bean depends on another bean of the same scope.

When two beans have the same custom scope and depend on each other (see thread dump in screenshot: CouchDbDatabaseName and MandantLuceneCouchDbConnector), I randomly get a livelock. 

![threaddump](https://cloud.githubusercontent.com/assets/12183470/19076968/07f235ae-8a4b-11e6-92d0-4ea0835267b6.png)

This PR should fix this.
